### PR TITLE
Visualize performance testing result by adding bar charts

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+### Goal
+
+### Changes
+
+1.
+2.
+
+### Screenshot of Results
+
+### TODO

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "cli-progress": "^3.12.0",
     "dotenv": "^16.3.1",
-    "puppeteer": "^21.5.2"
+    "puppeteer": "^21.5.2",
+    "uuid": "^9.0.1"
   }
 }

--- a/src/loadPage.js
+++ b/src/loadPage.js
@@ -1,3 +1,5 @@
+import { v4 as uuid } from "uuid";
+
 import { getBrowser } from "./helper/puppeteer";
 import {
   bytesToMB,
@@ -5,6 +7,9 @@ import {
   objAverage,
   sleep,
 } from "./helper/utils.js";
+import { baseExtChartSettings } from "./report/chart";
+
+const BASE_EXT = process.env.BASE_EXT || "no ext";
 
 const loadPage = async (url, options) => {
   const browser = await getBrowser(options);
@@ -42,6 +47,59 @@ const loadPage = async (url, options) => {
     subResourcesDuration: performanceTiming.subResourcesDuration,
     jsHeapUsedSize: bytesToMB(metrics.JSHeapUsedSize),
   };
+};
+
+export const generateCharts = (results) => {
+  const extNames = Object.keys(results);
+  const data = {
+    taskDuration: [],
+    pageLoadDuration: [],
+    jsHeapUsedSize: [],
+  };
+
+  extNames.forEach((extName) => {
+    data.taskDuration.push({
+      x: extName,
+      value: results[extName].taskDuration,
+      ...(extName == BASE_EXT && baseExtChartSettings),
+    });
+
+    data.pageLoadDuration.push({
+      x: extName,
+      value: results[extName].pageLoadDuration,
+      ...(extName == BASE_EXT && baseExtChartSettings),
+    });
+
+    data.jsHeapUsedSize.push({
+      x: extName,
+      value: results[extName].jsHeapUsedSize,
+      ...(extName == BASE_EXT && baseExtChartSettings),
+    });
+  });
+
+  const uniqueId = uuid().substring(0, 8);
+  const charts = [
+    {
+      data: data.taskDuration,
+      title: "Task Duration(ms)",
+      containerId: `${uniqueId}-load-page-task-duration-container`,
+      axis: ["Extension", "Time (ms)"],
+    },
+    {
+      data: data.pageLoadDuration,
+      title: "Page Load Duration(ms)",
+      containerId: `${uniqueId}-load-page-page-load-duration-container`,
+      axis: ["Extension", "Time (ms)"],
+    },
+    {
+      data: data.jsHeapUsedSize,
+      title: "JS Heap Used Size(MB)",
+      containerId: `${uniqueId}-load-page-js-heap-used-size-container`,
+      axis: ["Extension", "Size (MB)"],
+    },
+  ];
+
+  return charts;
 };
 
 const execute = async ({ url, testTitle }) => {
@@ -85,7 +143,8 @@ const execute = async ({ url, testTitle }) => {
       url,
     },
     results,
-    base: "no ext",
+    base: BASE_EXT,
+    charts: generateCharts(results),
   };
 };
 

--- a/src/report/chart.js
+++ b/src/report/chart.js
@@ -1,0 +1,55 @@
+export const generateChartHtml = (charts) => {
+  let html = '<div style="display: flex">';
+
+  charts.map((chart) => {
+    html += `
+      <div id=${chart.containerId} style="width: 400px; height: 300px"></div>
+    `;
+  });
+
+  html += `</div>`;
+
+  return html;
+};
+
+export const generateChartScript = (charts) => {
+  const drawBarChart = () => {
+    charts.map((c) => {
+      // eslint-disable-next-line no-undef
+      const chart = anychart.bar();
+
+      chart.bar(c.data);
+      chart.title(c.title);
+
+      chart.container(c.containerId);
+      chart.xAxis().title(c.axis[0]);
+      chart.yAxis().title(c.axis[1]);
+      chart.draw();
+    });
+  };
+
+  return `
+    <script>
+      const charts = ${JSON.stringify(charts)};
+      anychart.onDocumentReady(${drawBarChart.toString()})
+    </script>
+  `;
+};
+
+export const baseExtChartSettings = {
+  normal: {
+    fill: "#b3cf99",
+    stroke: null,
+    label: { enabled: true },
+  },
+  hovered: {
+    fill: "#b3cf99",
+    stroke: null,
+    label: { enabled: true },
+  },
+  selected: {
+    fill: "#b3cf99",
+    stroke: null,
+    label: { enabled: true },
+  },
+};

--- a/src/report/generator.js
+++ b/src/report/generator.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 import fs from "fs";
 
+import { generateChartHtml, generateChartScript } from "./chart";
 import { metrics } from "../helper/metrics";
 import { toISOLocal, yyyyMMddHHmm } from "../helper/datetime";
 import { internalCss } from "./style";
@@ -26,8 +27,9 @@ export const generateReport = (reportContents) => {
   `;
 
   let contentHtml = "";
+  const allCharts = [];
   reportContents.map((content, idx) => {
-    const { title, meta, results, base } = content;
+    const { title, meta, results, base, charts } = content;
     const listElements = {
       ...meta,
       ["percentage highlight threshold"]: `+${PERCENTAGE_THRESHOLD}%`,
@@ -37,8 +39,11 @@ export const generateReport = (reportContents) => {
         <h2>Test ${idx + 1}: ${title}</h2>
         ${objToUlElement(listElements)}
         ${resultsToHtmlTable(results, base)}
+        ${charts && generateChartHtml(charts)}
       </div>
     `;
+
+    allCharts.push(...charts);
   });
 
   const header = process.env.HEADER
@@ -49,12 +54,14 @@ export const generateReport = (reportContents) => {
   const html = `
     <html>
       <head>
+        <script src="https://cdn.anychart.com/releases/8.0.0/js/anychart-base.min.js"></script>
         <h1>${header}</h1>
         <div>${"Timestamp: " + toISOLocal(d)}</div>
         <style>${internalCss}</style>
       </head>
       <body>
         ${metricsHtml}
+        ${generateChartScript(allCharts)}
         ${contentHtml}
       </body>
     </html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3214,6 +3214,11 @@ urlpattern-polyfill@9.0.0:
   resolved "https://registry.yarnpkg.com/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz#bc7e386bb12fd7898b58d1509df21d3c29ab3460"
   integrity sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==
 
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
 v8flags@^3.1.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.2.0.tgz#b243e3b4dfd731fa774e7492128109a0fe66d656"


### PR DESCRIPTION
### Goal
Visualize performance testing result by adding bar charts

### Changes

1. Using `anychart` to draw bar chart of testing results so as to visualize `task duration`, `page load duration` and `js heap used size`
2. Add PR template

### Screenshot of Results
<img width="1262" alt="Screenshot 2023-12-10 at 12 03 46 AM" src="https://github.com/joannechen1223/webext-profiler/assets/22555930/87eb0769-9029-4674-8f64-f2594c86f331">


### TODO
N/A